### PR TITLE
Updated password attribute to be hashed w/ SHA512

### DIFF
--- a/src/JSON/exampleUsers.json
+++ b/src/JSON/exampleUsers.json
@@ -1,7 +1,7 @@
 [
     {
       "user_id": "583c3ac3f38e84297c002546",
-      "pass": "Re$3tMe1",
+      "pass": "dce3cfd9eca4f16e32beda1e40b46d0c298cab660deaf59da60f4073ca9421768da645c3186523cf99957cda60848b4e877e936a8cd049216ef5b1dae2d6c82e",
       "staff_id": "abc000",
       "email": "test@test.com",
       "name": "test@test.com",
@@ -13,7 +13,7 @@
     },
     {
       "user_id": "583c5484cb79a5fe593425a9",
-      "pass": "Re$3tMe2",
+      "pass": "706613378c5b819859a19d2f980714fd8e4178604d2ee2903d7113677c8e713791631a941107d399895d93dca20579e13c0d7f00264298b8a9971fd8a80b9f46",
       "staff_id": "abc111",
       "email": "test1@test.com",
       "name": "test1@test.com",
@@ -25,7 +25,7 @@
     },
     {
       "user_id": "583c57672c7686377d2f66c9",
-      "pass": "Re$3tMe3",
+      "pass": "85df831a04a93e7b8a131555a141a718a7118358138ba18c1c3e02fa3d0a87ed82184dab7377826addf36e9e99f310a977b64581bb4ba60a0b06726261203f7b",
       "staff_id": "abc222",
       "email": "aaa@aaa.com",
       "name": "aaa@aaa.com",
@@ -37,7 +37,7 @@
     },
     {
       "user_id": "5840b954da0529cd293d76fe",
-      "pass": "Re$3tMe4",
+      "pass": "0f3fe1651e992a241501979338b39cac87cb32b18130810e2b4aeec645af8af6d6289b3ac70aa526da02a57e31a40879b7e7f2e80a08c8d0e796206e3f0f4aba",
       "staff_id": "abc444",
       "email": "a@a.com",
       "name": "a@a.com",


### PR DESCRIPTION
Hey @ACipherEXE, wanted to get this updated really quick to get rid of the password in plaintext and replace it with the SHA512 fingerprint. 

For reference in case we need to go back to it later, I used https://codebeautify.org/sha512-hash-generator :)

Also, we can look at an earlier branch to view the passwords in plaintext like [SampleUserJSON](https://github.com/ACipherEXE/sweepster/tree/SampleUserJSON)
